### PR TITLE
Fixed problem when serving blog over HTTPS and using Disqus

### DIFF
--- a/app/views/blogo/posts/_disqus_comments.html.erb
+++ b/app/views/blogo/posts/_disqus_comments.html.erb
@@ -15,7 +15,7 @@
 
     (function () {
       var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-      dsq.src = 'http://' + disqus_shortname + '.disqus.com/' + disqus_script;
+      dsq.src = document.location.protocol + '//' + disqus_shortname + '.disqus.com/' + disqus_script;
       (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     }());
   </script>


### PR DESCRIPTION
When you run the blog on a HTTPS server you get this error message when Disqus is activated:

    Mixed Content: The page at 'https://temponia.com/blog/hofstadters-law-violated' was loaded over HTTPS, but requested an insecure script 'http://temponia.disqus.com/embed.js'. This request has been blocked; the content must be served over HTTPS.

This uses the protocol returned by javascript to determine if it should request the JS over HTTP or HTTPS.